### PR TITLE
Chore/build green next detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Mega Site
+
+This repository contains the Next.js application for the "mega-site" project deployed to Vercel.
+
+## Build Green Checklist
+
+This project uses a PNPM-managed Next.js app located in the `ST_MARYS_FRAMEWORK` folder. To ensure that Vercel builds and deploys correctly, follow this checklist:
+
+- Set the **Root Directory** in Vercel to `ST_MARYS_FRAMEWORK`.
+- Use the **Next.js** framework preset.
+- Use PNPM commands:
+  - **Install Command**: `pnpm install --frozen-lockfile`
+  - **Build Command**: `pnpm build`
+- Ensure **Node.js 20** runtime (compatible with `"engines": { "node": ">=18 <=20" }` in package.json).
+- The `package.json` includes `"next"`, `"react"`, and `"react-dom"` dependencies and standard `dev`, `build`, `start`, `lint` scripts.
+- `tsconfig.json` defines `"baseUrl": "."` and `"paths": { "@/*": ["./*"] }` to support absolute imports.
+- Environment variables are optional and read via `lib/env.ts` so that missing values do not break the build. Features can be toggled with `NEXT_PUBLIC_FEATURE_SMILE_QUIZ`, `NEXT_PUBLIC_FEATURE_CHATDOCK`, and `NEXT_PUBLIC_FEATURE_3DVIEWER`.
+- Keep the lockfile (`pnpm-lock.yaml`) committed and do not mix package managers.
+- If adding API routes that rely on Node‑only libraries (e.g., `fs`), add `export const runtime = 'nodejs';` at the top of the route file.
+
+Refer to the documentation in `/ST_MARYS_FRAMEWORK` for development instructions.

--- a/ST_MARYS_FRAMEWORK/lib/env.ts
+++ b/ST_MARYS_FRAMEWORK/lib/env.ts
@@ -1,0 +1,10 @@
+// lib/env.ts
+// Centralized optional environment variables accessor to avoid build-time errors.
+// Access values via process.env but do not throw during import.
+// Only assert the presence of variables at runtime when feature is executed.
+
+export const env = {
+  NEXT_PUBLIC_FEATURE_SMILE_QUIZ: process.env.NEXT_PUBLIC_FEATURE_SMILE_QUIZ ?? 'false',
+  NEXT_PUBLIC_FEATURE_CHATDOCK: process.env.NEXT_PUBLIC_FEATURE_CHATDOCK ?? 'false',
+  NEXT_PUBLIC_FEATURE_3DVIEWER: process.env.NEXT_PUBLIC_FEATURE_3DVIEWER ?? 'false',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mega-site-root",
+  "private": true,
+  "scripts": {
+    "postinstall": "pnpm --dir ST_MARYS_FRAMEWORK install --frozen-lockfile",
+    "build": "pnpm --dir ST_MARYS_FRAMEWORK build",
+    "dev": "pnpm --dir ST_MARYS_FRAMEWORK dev",
+    "start": "pnpm --dir ST_MARYS_FRAMEWORK start"
+  },
+  "packageManager": "pnpm@8.15.0",
+  "engines": { "node": ">=18 <=20" }
+}


### PR DESCRIPTION
This PR adds a safe environment variable accessor and a build green checklist to aid Vercel deployments.

- Adds `lib/env.ts` to centralise reads of optional environment variables and prevent build-time crashes. Each feature flag (`NEXT_PUBLIC_FEATURE_SMILE_QUIZ`, `NEXT_PUBLIC_FEATURE_CHATDOCK`, `NEXT_PUBLIC_FEATURE_3DVIEWER`) defaults to `false` when not provided.
- Adds a top-level `README.md` describing the project and a Build Green Checklist with instructions for setting the Vercel root directory, PNPM commands, Node.js version, tsconfig paths and engine constraints.

No existing app code is moved or removed.https://github.com/drnickmaxwell-wq/mega-site
