### PR TITLE
R-DEPLOY – Configure Vercel and ensure green build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.next
+node_modules/
+.env*
+.DS_Store

--- a/ST_MARYS_FRAMEWORK/app/about/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/about/page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return null;
+}

--- a/ST_MARYS_FRAMEWORK/app/contact/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/contact/page.tsx
@@ -1,0 +1,3 @@
+export default function Contact() {
+  return null;
+}

--- a/ST_MARYS_FRAMEWORK/app/health/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/health/page.tsx
@@ -1,0 +1,3 @@
+export default function Health() {
+  return <pre>ok</pre>;
+}

--- a/ST_MARYS_FRAMEWORK/app/health/route.ts
+++ b/ST_MARYS_FRAMEWORK/app/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}

--- a/ST_MARYS_FRAMEWORK/app/treatments/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/treatments/page.tsx
@@ -1,0 +1,3 @@
+export default function Treatments() {
+  return null;
+}

--- a/ST_MARYS_FRAMEWORK/lib/env.ts
+++ b/ST_MARYS_FRAMEWORK/lib/env.ts
@@ -1,0 +1,3 @@
+export function getEnv(key: string, defaultValue?: string): string | undefined {
+  return process.env[key] ?? defaultValue;
+}


### PR DESCRIPTION
This PR prepares the St Mary’s House framework for a successful Vercel deployment:\n\n- Fix empty pages: added default exports to `app/about/page.tsx`, `app/contact/page.tsx` and `app/treatments/page.tsx` to prevent "not a module" build errors.\n- Health endpoint: created `app/health/page.tsx` and `app/health/route.ts` returning `ok` for liveness probes.\n- Environment util: added `lib/env.ts` to safely read environment variables.\n- Housekeeping: added a project-wide `.gitignore` to ignore `.next`, `node_modules`, `.env*` and other artifacts.\n\nThe tsconfig alias is already correct and we keep the existing `next.config.js`. With these changes the Next.js build should detect and render the app correctly. After merging, the Vercel preview should build cleanly and `/health` should return ok.