### PR TITLE
R0 — Build Health

### DIFF
--- a/ST_MARYS_FRAMEWORK/app/about/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/about/page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return null;
+}

--- a/ST_MARYS_FRAMEWORK/app/contact/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/contact/page.tsx
@@ -1,0 +1,3 @@
+export default function Contact() {
+  return null;
+}

--- a/ST_MARYS_FRAMEWORK/app/patient-care/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/patient-care/page.tsx
@@ -1,0 +1,3 @@
+export default function PatientCare() {
+  return null;
+}

--- a/ST_MARYS_FRAMEWORK/app/resources/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/resources/page.tsx
@@ -1,0 +1,3 @@
+export default function Resources() {
+  return null;
+}

--- a/ST_MARYS_FRAMEWORK/app/treatments/page.tsx
+++ b/ST_MARYS_FRAMEWORK/app/treatments/page.tsx
@@ -1,0 +1,3 @@
+export default function Treatments() {
+  return null;
+}

--- a/app/health/page.tsx
+++ b/app/health/page.tsx
@@ -1,0 +1,3 @@
+export default function Health() {
+  return <pre>ok</pre>;
+}

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "name": "mega-site",
+  "workspaces": ["ST_MARYS_FRAMEWORK"],
+  "scripts": {
+    "preinstall": "cp -f ST_MARYS_FRAMEWORK/pnpm-lock.yaml ./pnpm-lock.yaml || true",
+    "dev": "pnpm --filter st-marys-house-dental-care dev",
+    "build": "pnpm --filter st-marys-house-dental-care build",
+    "start": "pnpm --filter st-marys-house-dental-care start",
+    "lint": "pnpm --filter st-marys-house-dental-care lint"
+  },
+  "engines": {
+    "node": ">=18 <=20",
+    "pnpm": ">=8.0.0"
+  },
+  "packageManager": "pnpm@8.15.0"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - ST_MARYS_FRAMEWORK

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "next/core-web-vitals",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR ensures the Next.js app in this repo builds successfully on Vercel.

- Adds a root-level package.json and pnpm-workspace.yaml to reference the existing ST_MARYS_FRAMEWORK app and provide scripts for build/dev.
- Adds next.config.mjs and tsconfig.json at the repo root with standard settings.
- Creates app/health/page.tsx and app/health/route.ts to provide a simple health check route returning { ok: true }.
- Adds default exports to previously empty pages (about, contact, patient-care, resources, treatments) so they compile.

After merging, the app should detect as a Next.js project and the /health route should return ok.
